### PR TITLE
Add optional 2nd ingress to allow splitting traffic for public & VPN

### DIFF
--- a/charts/odk-central/CHANGELOG.md
+++ b/charts/odk-central/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+This file documents all notable changes to the ODK Central Helm Chart.
+The release numbering uses [semantic versioning](http://semver.org).
+
+## 0.3.0
+
+- Add optional 2nd ingress to allow splitting traffic for public & VPN (#2)
+
+## 0.2.0
+
+- Update redis-ha subchart and enable haproxy (76abe4a48d3eecf0c76c5ad060235cf15a049497)
+
+## 0.1.3
+
+- Fix `ENKETO_URL` and `DOMAIN` environment variables (dc8a34f4aa46a5d3be448385360042bea4216052)
+
+## 0.1.2
+
+- Fix missing Enketo secrets (d2c8a86499f5ab6d234abd8be6c24e545ed96c0c)
+
+## 0.1.1
+
+- Build chart dependencies in CI (3c181959ad18513e9dd7d9f29366d960f67682cb)
+- Remove extraneous template files (3a164ff69dc38797fdfb1e29ab408f25a3fdddb0)
+
+## 0.1.0
+
+- Initial release (#1)

--- a/charts/odk-central/Chart.yaml
+++ b/charts/odk-central/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/odk-central/charts/backend/values.yaml
+++ b/charts/odk-central/charts/backend/values.yaml
@@ -48,6 +48,18 @@ service:
   type: ClusterIP
   port: 8383
 
+ingressApp:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
 ingress:
   enabled: false
   className: ""

--- a/charts/odk-central/charts/frontend/templates/ingressApp.yaml
+++ b/charts/odk-central/charts/frontend/templates/ingressApp.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingressApp.enabled -}}
+{{- $fullName := include "frontend.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingressApp.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingressApp.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingressApp.annotations "kubernetes.io/ingress.class" .Values.ingressApp.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-app
+  labels:
+    {{- include "frontend.labels" . | nindent 4 }}
+  {{- with .Values.ingressApp.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingressApp.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingressApp.className }}
+  {{- end }}
+  {{- if .Values.ingressApp.tls }}
+  tls:
+    {{- range .Values.ingressApp.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingressApp.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
Sample config:

```yaml
frontend:
  # VPN-only access for web users
  ingress:
    enabled: true
    annotations:
      nginx.org/mergeable-ingress-type: master
      nginx.ingress.kubernetes.io/whitelist-source-range: "1.2.3.4"
    hosts:
      - host: "my.odkcentral.com"
        paths:
          - path: /
  # Public access for app users
  ingressApp:
    enabled: true
    annotations:
      nginx.org/mergeable-ingress-type: minion
    hosts:
      - host: "my.odkcentral.com"
        paths:
          - path: /v1/key
```

References
- hnec-vr/libya-elections#3970