### PR TITLE
Set the Host header for liveness and readiness checks for the ODK Central frontend.

### DIFF
--- a/charts/odk-central/charts/frontend/templates/deployment.yaml
+++ b/charts/odk-central/charts/frontend/templates/deployment.yaml
@@ -44,10 +44,16 @@ spec:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+              - name: Host
+                value: "{{ .Values.global.centralDomain }}"
           readinessProbe:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+              - name: Host
+                value: "{{ .Values.global.centralDomain }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
The PR fixes liveness and readiness probes on the ODK Central frontend, which now returns a 421 response if a request's `Host` header does not match the expected domain name.