### PR TITLE
Bump versions: ODK Central to 0.3.4 and ODK Publish to 0.1.3.

### DIFF
--- a/charts/odk-central/CHANGELOG.md
+++ b/charts/odk-central/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the ODK Central Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
 
+## 0.3.4
+
+- Add a README file. (#11)
+
 ## 0.3.3
 
 - Increment `appVersion` to match the deployed version of ODK Central (v2024.3.1) and pin all container versions for odk-central chart.

--- a/charts/odk-central/Chart.yaml
+++ b/charts/odk-central/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/odk-publish/CHANGELOG.md
+++ b/charts/odk-publish/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to the ODK Publish Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.1.3
+
+- Add README and CHANGELOG files. (#10)
+
 ## 0.1.2
 
 - Add the ability to run separate ASGI and WSGI deployments. (#9)

--- a/charts/odk-publish/Chart.yaml
+++ b/charts/odk-publish/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This is to fix the chart-releaser issues:
- https://github.com/caktus/helm-charts/actions/runs/13996377867/job/39192465275
- https://github.com/caktus/helm-charts/actions/runs/13996335025/job/39192323086