### PR TITLE
Fix 'no repository definition' in release GA workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           helm repo add dandydev https://dandydeveloper.github.io/charts
           cd charts/odk-central && helm dependency build
+          helm repo add infisical-helm-charts https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+          cd charts/publish-mdm && helm dependency build
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0


### PR DESCRIPTION
This PR fixes an [error](https://github.com/caktus/helm-charts/actions/runs/15427482621/job/43417900474) occurring when the `release` GA workflow is run, due to the new Infisical dependency for the `publish-mdm` chart:
```
Error: no repository definition for https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
```

This is due to a [known issue](https://github.com/helm/chart-releaser-action/issues/74) in the chart-releaser action.