### PR TITLE
Upgrade the version of the Infisical subchart in the Publish MDM chart.

### DIFF
--- a/charts/publish-mdm/CHANGELOG.md
+++ b/charts/publish-mdm/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to the Publish MDM Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.1.6
+
+- Upgrade the Infisical subchart to 1.7.2. (#17)
+
 ## 0.1.5
 
 - Add Infisical subchart for Publish MDM. (#14)

--- a/charts/publish-mdm/Chart.lock
+++ b/charts/publish-mdm/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.4
 - name: infisical-standalone
   repository: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
-  version: 1.5.0
-digest: sha256:f1d9e7ba6b33e6876ece1b45f1c41638cf39b20676c9cce37ada8df4adb1845b
-generated: "2025-05-10T03:14:27.930754625+03:00"
+  version: 1.7.2
+digest: sha256:37b5b9e0411085374eb2b9b3f3fd98dea528aaad8840bf10dd679d4f4a928ddf
+generated: "2025-12-01T17:02:04.393706528+03:00"

--- a/charts/publish-mdm/Chart.yaml
+++ b/charts/publish-mdm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -34,6 +34,6 @@ dependencies:
     condition: asgi.enabled
   - name: infisical-standalone
     repository: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
-    version: 1.5.0
+    version: 1.7.2
     alias: infisical
     condition: infisical.enabled

--- a/charts/publish-mdm/charts/publish-mdm/templates/publish-mdm-secret.yaml
+++ b/charts/publish-mdm/charts/publish-mdm/templates/publish-mdm-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secretVolumeSecretName }}
+  labels:
+    {{- include "publish-mdm.labels" . | nindent 4 }}
+{{- with .Values.secretVolumeSecrets }}
+data:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/publish-mdm/charts/publish-mdm/values.yaml
+++ b/charts/publish-mdm/charts/publish-mdm/values.yaml
@@ -119,3 +119,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+secretVolumeSecrets: {}
+
+secretVolumeSecretName: publish-mdm-secrets


### PR DESCRIPTION
This PR upgrades the Infisical subchart of the Publish MDM chart to the [latest version](https://github.com/Infisical/infisical/blob/main/helm-charts/infisical-standalone-postgres/CHANGELOG.md), which includes a fix for pulling the redis image as `bitnami/redis`  now requires a subscription. Also adds a Secret from which a secret volume can be created.