### PR TITLE
Upgrade to ODK Central v2025.4.2 and bump version.

### DIFF
--- a/charts/odk-central/CHANGELOG.md
+++ b/charts/odk-central/CHANGELOG.md
@@ -4,6 +4,14 @@ This file documents all notable changes to the ODK Central Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
 
+## 0.4.1
+
+- Upgrade to ODK Central v2025.4.2.
+
+## 0.4.0
+
+- Upgrade to ODK Central v2025.1.2.
+
 ## 0.3.4
 
 - Add a README file. (#11)

--- a/charts/odk-central/Chart.yaml
+++ b/charts/odk-central/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2025.1.2"
+appVersion: "v2025.4.2"
 
 dependencies:
   - name: redis-ha

--- a/charts/odk-central/charts/backend/values.yaml
+++ b/charts/odk-central/charts/backend/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/caktus/central-service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v2025.1.2
+  tag: v2025.4.2
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/odk-central/charts/enketo/values.yaml
+++ b/charts/odk-central/charts/enketo/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/caktus/central-enketo
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v2025.1.2
+  tag: v2025.4.2
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/odk-central/charts/frontend/values.yaml
+++ b/charts/odk-central/charts/frontend/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/caktus/central-nginx
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v2025.1.2
+  tag: v2025.4.2
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR upgrades ODK Central to v2025.4.2 from v2025.1.2 and bumps the chart version to 0.4.1.

Related PR: https://github.com/caktus/central/pull/5