### PR TITLE
Add existingSecret param to odk-central chart for gitops workflows

### DIFF
--- a/charts/odk-central/charts/backend/templates/deployment.yaml
+++ b/charts/odk-central/charts/backend/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "backend.fullname" . }}
+            {{- with .Values.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           volumeMounts:
             - name: secret-volume
               readOnly: true

--- a/charts/odk-central/charts/backend/values.yaml
+++ b/charts/odk-central/charts/backend/values.yaml
@@ -19,6 +19,10 @@ config: {}
   # pyxformHost:
   # pyxformPort:
 
+# Optional pre-existing Secret to also load via envFrom alongside environmentVariables.
+# Keys from this secret take precedence. Useful for GitOps where plaintext secrets cannot be committed.
+existingSecret: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/odk-central/charts/enketo/templates/deployment.yaml
+++ b/charts/odk-central/charts/enketo/templates/deployment.yaml
@@ -73,6 +73,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "enketo.fullname" . }}
+            {{- with .Values.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           volumeMounts:
             - name: secret-volume
               readOnly: true

--- a/charts/odk-central/charts/enketo/values.yaml
+++ b/charts/odk-central/charts/enketo/values.yaml
@@ -14,6 +14,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Optional pre-existing Secret to also load via envFrom alongside environmentVariables.
+# Keys from this secret take precedence. Useful for GitOps where plaintext secrets cannot be committed.
+existingSecret: ""
+
 config:
   # Set to 64-character random string
   # enketoSecret: ""

--- a/charts/odk-central/charts/frontend/templates/deployment.yaml
+++ b/charts/odk-central/charts/frontend/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "frontend.fullname" . }}
+            {{- with .Values.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/odk-central/charts/frontend/values.yaml
+++ b/charts/odk-central/charts/frontend/values.yaml
@@ -18,6 +18,10 @@ config: {}
   # enketoUrl: ""
   # serviceUrl: ""
 
+# Optional pre-existing Secret to also load via envFrom alongside environmentVariables.
+# Keys from this secret take precedence. Useful for GitOps where plaintext secrets cannot be committed.
+existingSecret: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
- The chart has an `environmentVariables` params, which creates a secret that is used in deployment `envFrom`.
- Using gitops / argocd to deploy this, the env vars would have to be committed to the repo.
- Alternatively we could do an awkward kustomization workaround, but it's not pretty.
- Simple fix is to add an `existingSecret` param to values.yaml, where the user can manage an external secret (e.g. sealed-secrets) and inject the vars as env vars into the deployment.